### PR TITLE
Auto calculate IC while batch analysing, fixed bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ This is a part of the supplements from my bachelor thesis **How’s _Wolbachia_ 
 
 All analyses were performed using R Statistical Software (v4.2.0; R Core Team, 2022) and RStudio (v2023.9.0.463).
 
-## 3 Features after thesis submission
+## 3 Changes after thesis submission
 
-The original version corresponding to thesis submission is at the [commit 01edbdf](https://github.com/zzzhehao/wsp-Real-time-PCR-Analysis/tree/01ebdbf8a724d36446cb1e920add2505835d4866) 
+[Commit 01edbdf](https://github.com/zzzhehao/wsp-Real-time-PCR-Analysis/tree/01ebdbf8a724d36446cb1e920add2505835d4866) corresponds to the code in my thesis. Several new features as listed below has been added to the function and I recommend the newest version.
 
 - **feat:** add wsp_analysis_batch() as bulk analysis option
 - **feat:** add arguments in function to customise IC and standard curve parameter
@@ -30,11 +30,17 @@ The original version corresponding to thesis submission is at the [commit 01edbd
 - **feat:** no need to manually check for required packages  
 - **perf:** improve log formatting and layout  
 - **docs:** remove evaluation code information in plot document, expected to be added back as independent document in the future
-- **fix**: removed customization of standard curve parameters, this now should be manually altered in **wsp-qPCR Evaluation.R** at line 42-49
+- **fix**: removed customization of standard curve parameters, this now should be manually altered in _wsp-qPCR Evaluation.R_ at line 42-49
 - **docs**: add EvaCode documentation in README
 - **feat**: adapt new workflow: interplate calibrator now has new default: "IPC", can also be specified manually; old workflow can be switched by specifying `ancient = True`
 - **feat**: adapt new workflow: sample name now should be assigned to 'sample name' in StepOne software in default
-
+- **feat**: add optional argument `threshold` to display horizontal redline in amplification plot
+- **fix**: Ct_Mean is now named as Ct_Median. **Important**: this is only a naming change, the calculation remains unchanged, see [line 143](https://github.com/zzzhehao/wsp-Real-time-PCR-Analysis/blob/01ebdbf8a724d36446cb1e920add2505835d4866/wsp-qPCR%20Evaluation.R#L143) in _wsp-qPCR Evaluation.R_ at the original submission commit 
+- **feat**: Ct and SD from IC will be auto calculated while batch analysing data if not specified
+- **fix**: customized IC name didn't trigger calibration
+- **feat**: add IC calibration message in log
+- **fix**: threshold was not passed to nested function while batch analysing data
+ 
 ## 4 Analyse Data
 
 ### 4.1 Raw file

--- a/wsp-qPCR Evaluation.R
+++ b/wsp-qPCR Evaluation.R
@@ -1,4 +1,4 @@
-wsp_analysis <- function(xls_filePath, Ct_ic=NULL, SD_ic=NULL, in_batch=FALSE, ancient=FALSE, IC_name="IPC") {
+wsp_analysis <- function(xls_filePath, Ct_ic=NULL, SD_ic=NULL, in_batch=FALSE, ancient=FALSE, IC_name="IPC", threshold=NULL) {
   
   # Install requirements
   if (!require("Require")) install.packages("Require")
@@ -372,6 +372,11 @@ wsp_analysis <- function(xls_filePath, Ct_ic=NULL, SD_ic=NULL, in_batch=FALSE, a
             aspect.ratio = 1,
             plot.caption = element_text(hjust = 0))
     
+    if (!is.na(threshold)) {
+      plota <- plota +
+        geom_hline(yintercept = threshold, color = "red")
+    }
+    
     return(plota)
     plota$layers <- list()
   }
@@ -380,21 +385,6 @@ wsp_analysis <- function(xls_filePath, Ct_ic=NULL, SD_ic=NULL, in_batch=FALSE, a
   amplots <- map(ampl, all.plot.a)
   
   
-  
-  #### Plots info ####
-  # lgd <- ggplot()+
-  #   labs(title = paste0("Evaluation Code Inspection Infos"),
-  #        caption = paste0("\n","1.Digit","\n",
-  #                         "1,5: M77/70 too high; 2,6: M77/70 too low","\n\n",
-  #                         "2. Digit","\n",
-  #                         "1,3,5,6,7,9,11,13,14,15: wA1 involving DB","\n\n",
-  #                         "3. Digit","\n",
-  #                         "1: iM70 too high; 2: Ct too low; 3: iM70 too high, Ct too low"),
-  #   ) +
-  #   theme_USGS_box() +
-  #   theme(plot.caption.position = "panel",
-  #         aspect.ratio = 0.01,
-  #         plot.caption = element_text(hjust = 0))
   
   #### Arrange plots ####
   combinelist <- function (list1, list2) {
@@ -435,7 +425,7 @@ wsp_analysis <- function(xls_filePath, Ct_ic=NULL, SD_ic=NULL, in_batch=FALSE, a
 
 }
 
-wsp_analysis_batch <- function(xls_folderPath, Ct_ic=NULL, SD_ic=NULL, ancient=FALSE, IC_name="IPC") {
+wsp_analysis_batch <- function(xls_folderPath, Ct_ic=NULL, SD_ic=NULL, ancient=FALSE, IC_name="IPC", threshold=NULL) {
   #### Install requirements ####
   if (!require("Require")) install.packages("Require")
   Require::Require(c("ggplot2", "readxl", "plyr", "rlist", "tidyverse", "ggpubr", "gridExtra", "log4r"), require = FALSE)

--- a/wsp-qPCR Evaluation.R
+++ b/wsp-qPCR Evaluation.R
@@ -78,10 +78,10 @@ wsp_analysis <- function(xls_filePath, Ct_ic=NULL, SD_ic=NULL, in_batch=FALSE, a
   # Import result table
   output <- as_tibble(readxl::read_xls(xls_filePath, sheet = "Results", range = "A8:S104"))
   if (ancient) {
-    colnames(output)[c(1,3,7,8)] <- c("Well_name","Sample","Ct","Ct_Mean") # imperfect dealing in original workflow on StepOne system: falsely assigned sample parameter
+    colnames(output)[c(1,3,7,8)] <- c("Well_name","Sample","Ct","Ct_Median") # imperfect dealing in original workflow on StepOne system: falsely assigned sample parameter
     IC_name <- "IC4" # Original workflow has assigned interplate calibrator with name "IC4", now can be specified or the default is set as "IPC", it is important that this remains consistent throughout whole project when using batch analysis
   } else {
-    colnames(output)[c(1,2,7,8)] <- c("Well_name","Sample","Ct","Ct_Mean")
+    colnames(output)[c(1,2,7,8)] <- c("Well_name","Sample","Ct","Ct_Median")
   }
   
   # set well no. in output
@@ -169,7 +169,7 @@ wsp_analysis <- function(xls_filePath, Ct_ic=NULL, SD_ic=NULL, in_batch=FALSE, a
     group_by(Gl_ID) %>%
     reframe(
       Sample = Sample, 
-      Ct_Mean = median(Ct), 
+      Ct_Median = median(Ct), 
       Tm1 = median(Tm1), 
       Tm2 = median(Tm2), 
       iM60 = median(`iM60`),
@@ -207,7 +207,7 @@ wsp_analysis <- function(xls_filePath, Ct_ic=NULL, SD_ic=NULL, in_batch=FALSE, a
   
   # 3.algorithm: negative double check
   sreport <- sreport %>% mutate(agr3 =  0+
-                                  ifelse(Ct_Mean < 30, 2, 0) + 
+                                  ifelse(Ct_Median < 30, 2, 0) + 
                                   ifelse(iM70>5.3, 1, 0) 
   )
   eva3 <- as_tibble(data.frame(agr3=c(0:3),eva3=c("Negative", rep("Inspect",3))))
@@ -230,15 +230,15 @@ wsp_analysis <- function(xls_filePath, Ct_ic=NULL, SD_ic=NULL, in_batch=FALSE, a
   
   # Calculate initial target copies
   # Calculate factor for calibrating IC
-  icfactor <- as.numeric((sreport %>% filter(Sample == "IC4") %>% select(Ct_Mean) / ic4 )) ^ -1 
+  icfactor <- as.numeric((sreport %>% filter(Sample == IC_name) %>% select(Ct_Median) / ic4 )) ^ -1 
   icfactor <- c(rep(icfactor, length(sreport$Sample)))
   # Calibrate IC
-  sreport <- sreport %>% mutate(Ct_cal = Ct_Mean * icfactor) 
+  sreport <- sreport %>% mutate(Ct_cal = Ct_Median * icfactor) 
   # Calculate target copies
   sreport <- sreport %>% mutate(`Initial target copies` = case_when(
     eva1 == "Quantify" ~ case_when(
-      eva2 == "wA1" ~ formatC(round(((10^(-1/slope.a1))^(y_intcpt.a1-Ct_Mean))*100, digit = 0), format = "e", digits = 2),
-      .default = formatC(round(((10^(-1/slope.a2b))^(y_intcpt.a2b-Ct_Mean))*100, digit = 0), format = "e", digits = 2)
+      eva2 == "wA1" ~ formatC(round(((10^(-1/slope.a1))^(y_intcpt.a1-Ct_Median))*100, digit = 0), format = "e", digits = 2),
+      .default = formatC(round(((10^(-1/slope.a2b))^(y_intcpt.a2b-Ct_Median))*100, digit = 0), format = "e", digits = 2)
     )
   ))
   
@@ -249,8 +249,11 @@ wsp_analysis <- function(xls_filePath, Ct_ic=NULL, SD_ic=NULL, in_batch=FALSE, a
     ", Double Infection: ", nrow((sreport %>% filter(DB == TRUE))),
     ", Inspection required: ", nrow((sreport %>% filter(`Suggest result` == "Inspect")))
   ))
+  
+  info(fileLogger, paste0("Adjusting Ct with factor: ", round(icfactor[1], 4)))
+  
   # Warning NTC
-  CtNTC <- (sreport %>% filter(Sample == "NTC"))$Ct_Mean
+  CtNTC <- (sreport %>% filter(Sample == "NTC"))$Ct_Median
   if (CtNTC < 30) {
     warn(fileLogger, paste0("Irregular NTC, Ct low, Ct: ",
                             CtNTC))
@@ -275,10 +278,10 @@ wsp_analysis <- function(xls_filePath, Ct_ic=NULL, SD_ic=NULL, in_batch=FALSE, a
   linfo <- select(
     left_join(
       select(output, c("Gl_ID", "Well")), 
-      select(sreport, c("Gl_ID", "Ct_Mean","Tm1", "Tm2", "iM70", "DB", "neg.readings", "M77_70", "Suggest result","Initial target copies")), 
+      select(sreport, c("Gl_ID", "Ct_Median","Tm1", "Tm2", "iM70", "DB", "neg.readings", "M77_70", "Suggest result","Initial target copies")), 
       by = "Gl_ID", 
       relationship = "many-to-many"), # Silence warning
-    c("Well","Gl_ID","Ct_Mean", "Tm1", "Tm2", "iM70", "DB", "neg.readings", "M77_70", "Suggest result","Initial target copies"))
+    c("Well","Gl_ID","Ct_Median", "Tm1", "Tm2", "iM70", "DB", "neg.readings", "M77_70", "Suggest result","Initial target copies"))
   linfo <- dlply(linfo,.(Well))
   l <- map2(l,linfo,list)
   
@@ -372,7 +375,7 @@ wsp_analysis <- function(xls_filePath, Ct_ic=NULL, SD_ic=NULL, in_batch=FALSE, a
             aspect.ratio = 1,
             plot.caption = element_text(hjust = 0))
     
-    if (!is.na(threshold)) {
+    if (!is.null(threshold)) {
       plota <- plota +
         geom_hline(yintercept = threshold, color = "red")
     }
@@ -450,8 +453,33 @@ wsp_analysis_batch <- function(xls_folderPath, Ct_ic=NULL, SD_ic=NULL, ancient=F
     "Number of Plate: ", length(files)
   ))
   
+  # Calculate IC Mean and SD
+  extract_ic <- function(path) {
+    res <- as_tibble(readxl::read_xls(path, sheet = "Results", range = "A8:S104"))
+    if (ancient) {
+      res <- res %>% select(c(3, 8))
+    } else {
+      res <- res %>% select(c(2, 8))
+    }
+    colnames(res) <- c("Sample", "Ct")
+    IC <- median(drop_na(res[res$Sample == IC_name, ])$Ct)
+    return(IC)
+  }
+  ICs <- na.omit(unlist(map(files, extract_ic)))
+  
+  if (is.null(Ct_ic)) {
+    Ct_ic = mean(ICs)
+  }
+  if (is.null(SD_ic)) {
+    SD_ic = sd(ICs)
+  }
+  
+  info(fileLogger, paste0(
+    "IC Mean: ", Ct_ic, ", IC SD: ", SD_ic
+  ))
+  
   #### Analyse ####
-  walk(.x=files, ~ wsp_analysis(xls_filePath = .x, Ct_ic = Ct_ic, SD_ic = SD_ic, in_batch=TRUE, ancient=ancient, IC_name=IC_name), .progress = TRUE)
+  walk(.x=files, ~ wsp_analysis(xls_filePath = .x, Ct_ic = Ct_ic, SD_ic = SD_ic, in_batch=TRUE, ancient=ancient, IC_name=IC_name, threshold = threshold), .progress = TRUE)
   
   info(fileLogger, paste0("Please be aware, the automatic analysis cannot replace manual inspection. Evaluation code will provide further detailed analysis results. \n", "# End of evaluation \n"))
 }


### PR DESCRIPTION
- **feat**: add optional argument `threshold` to display horizontal redline in amplification plot
- **fix**: Ct_Mean is now named as Ct_Median. **Important**: this is only a naming change, the calculation remains unchanged, see [line 143](https://github.com/zzzhehao/wsp-Real-time-PCR-Analysis/blob/01ebdbf8a724d36446cb1e920add2505835d4866/wsp-qPCR%20Evaluation.R#L143) in _wsp-qPCR Evaluation.R_ at the original submission commit 
- **feat**: Ct and SD from IC will be auto calculated while batch analysing data if not specified
- **fix**: customized IC name didn't trigger calibration
- **feat**: add IC calibration message in log
- **fix**: threshold was not passed to nested function while batch analysing data